### PR TITLE
Create members if they do not exist when receiving account details

### DIFF
--- a/payment-service/src/main/java/com/hedvig/paymentservice/domain/payments/Member.java
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/domain/payments/Member.java
@@ -237,6 +237,4 @@ public class Member {
 
         return matchingTransactions.get(0);
     }
-
-
 }

--- a/payment-service/src/main/java/com/hedvig/paymentservice/domain/trustlyOrder/sagas/AccountCreationSaga.java
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/domain/trustlyOrder/sagas/AccountCreationSaga.java
@@ -1,9 +1,11 @@
 package com.hedvig.paymentservice.domain.trustlyOrder.sagas;
 
+import com.hedvig.paymentservice.domain.payments.commands.CreateMemberCommand;
 import com.hedvig.paymentservice.domain.payments.commands.UpdateTrustlyAccountCommand;
 import com.hedvig.paymentservice.domain.trustlyOrder.events.AccountNotificationReceivedEvent;
 import lombok.val;
 import org.axonframework.commandhandling.gateway.CommandGateway;
+import org.axonframework.commandhandling.model.AggregateNotFoundException;
 import org.axonframework.eventhandling.saga.EndSaga;
 import org.axonframework.eventhandling.saga.SagaEventHandler;
 import org.axonframework.eventhandling.saga.StartSaga;
@@ -21,7 +23,15 @@ public class AccountCreationSaga {
     @SagaEventHandler(associationProperty = "accountId")
     @EndSaga
     public void on(AccountNotificationReceivedEvent event) {
+        try {
+            updateTrustlyAccount(event);
+        } catch (AggregateNotFoundException e) {
+            commandGateway.sendAndWait(new CreateMemberCommand(event.getMemberId()));
+            updateTrustlyAccount(event);
+        }
+    }
 
+    private void updateTrustlyAccount(AccountNotificationReceivedEvent event) {
         val command = new UpdateTrustlyAccountCommand(
                 event.getMemberId(),
                 event.getHedvigOrderId(),
@@ -39,5 +49,4 @@ public class AccountCreationSaga {
 
         commandGateway.sendAndWait(command);
     }
-
 }

--- a/payment-service/src/main/java/com/hedvig/paymentservice/query/trustlyOrder/enteties/TrustlyOrder.java
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/query/trustlyOrder/enteties/TrustlyOrder.java
@@ -6,8 +6,9 @@ import lombok.Getter;
 import lombok.Setter;
 
 import javax.persistence.*;
+
+import java.util.HashSet;
 import java.util.Set;
-import java.util.TreeSet;
 import java.util.UUID;
 
 @Entity
@@ -31,7 +32,7 @@ public class TrustlyOrder {
     String iframeUrl;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, orphanRemoval = true)
-    Set<TrustlyNotification> notifications = new TreeSet<>();
+    Set<TrustlyNotification> notifications = new HashSet<>();
 
     public void addNotification(TrustlyNotification notification) {
         notifications.add(notification);

--- a/payment-service/src/test/java/com/hedvig/paymentservice/trustly/testHelpers/TestData.java
+++ b/payment-service/src/test/java/com/hedvig/paymentservice/trustly/testHelpers/TestData.java
@@ -4,6 +4,7 @@ import com.hedvig.paymentService.trustly.commons.Currency;
 import com.hedvig.paymentService.trustly.commons.Method;
 import com.hedvig.paymentService.trustly.data.notification.Notification;
 import com.hedvig.paymentService.trustly.data.notification.NotificationParameters;
+import com.hedvig.paymentService.trustly.data.notification.notificationdata.AccountNotificationData;
 import com.hedvig.paymentService.trustly.data.notification.notificationdata.CreditData;
 import com.hedvig.paymentservice.domain.payments.events.TrustlyAccountCreatedEvent;
 import com.hedvig.paymentservice.services.trustly.dto.DirectDebitRequest;
@@ -12,6 +13,7 @@ import org.javamoney.moneta.Money;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.HashMap;
 import java.util.UUID;
 import javax.money.MonetaryAmount;
 import lombok.val;
@@ -94,6 +96,39 @@ public class TestData {
         val request = new Notification();
         request.setMethod(Method.CREDIT);
         request.setParams(params);
+        request.setVersion(1.1);
+
+        return request;
+    }
+
+    public static Notification makeTrustlyAccountNotificationRequest() {
+        val attributes = new HashMap<String, Object>();
+        attributes.put("directdebitmandate", "1");
+        attributes.put("lastdigits", TRUSTLY_ACCOUNT_LAST_DIGITS);
+        attributes.put("clearinghouse", TRUSTLY_ACCOUNT_CLEARING_HOUSE);
+        attributes.put("bank", TRUSTLY_ACCOUNT_BANK);
+        attributes.put("descriptor", TRUSTLY_ACCOUNT_DESCRIPTOR);
+        attributes.put("personid", TOLVANSSON_SSN);
+        attributes.put("name", TOLVAN_FIRST_NAME + TOLVANSSON_LAST_NAME);
+        attributes.put("address", TOLVANSSON_STREET);
+        attributes.put("zipcode", TOLVANSSON_ZIP);
+        attributes.put("city", TOLVANSSON_CITY);
+
+        val data = new AccountNotificationData();
+        data.setAccountId(TRUSTLY_ACCOUNT_ID);
+        data.setNotificationId(TRUSTLY_NOTIFICATION_ID);
+        data.setOrderId(TRUSTLY_ORDER_ID);
+        data.setMessageId(HEDVIG_ORDER_ID.toString());
+        data.setAttributes(attributes);
+
+        val parameters = new NotificationParameters();
+        parameters.setData(data);
+        parameters.setSignature("");
+        parameters.setUUID(TRUSTLY_NOTIFICATION_ID);
+
+        val request = new Notification();
+        request.setMethod(Method.ACCOUNT);
+        request.setParams(parameters);
         request.setVersion(1.1);
 
         return request;


### PR DESCRIPTION
- Includes tests for two cases:
  - Test where member does not exist and we get notification
   - Test where member does exist and we get notification
- Also includes a fix for the TrustlyOrder-read model