### PR TITLE
Set trustly iframe to use _self instead of default _top

### DIFF
--- a/payment-service/src/main/java/com/hedvig/paymentservice/services/trustly/TrustlyService.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/services/trustly/TrustlyService.kt
@@ -301,6 +301,7 @@ class TrustlyService(
       else
         plainFailUrl
     )
+    build.URLTarget("_self")
 
     val directDebitOrderRequest = build.request
     val gson = Gson()


### PR DESCRIPTION
Its causing issues in the web onboarding 🕸