### PR TITLE
only return members with dd connected

### DIFF
--- a/payment-service/src/main/java/com/hedvig/paymentservice/serviceIntergration/memberService/MemberServiceImpl.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/serviceIntergration/memberService/MemberServiceImpl.kt
@@ -1,5 +1,6 @@
 package com.hedvig.paymentservice.serviceIntergration.memberService
 
+import com.hedvig.paymentservice.domain.payments.DirectDebitStatus
 import com.hedvig.paymentservice.domain.payments.enums.PayinProvider
 import com.hedvig.paymentservice.query.member.entities.MemberRepository
 import com.hedvig.paymentservice.serviceIntergration.memberService.dto.Member
@@ -29,9 +30,12 @@ class MemberServiceImpl(
 
   override fun getMembersByPayinProvider(payinProvider: PayinProvider): List<String> {
     val members = memberRepository.findAll()
+
     return when (payinProvider) {
       PayinProvider.TRUSTLY -> {
-        members.filter { it.trustlyAccountNumber != null }
+        members.filter { it.trustlyAccountNumber != null
+          && it.directDebitStatus == DirectDebitStatus.CONNECTED
+        }
       }
       PayinProvider.ADYEN -> {
         members.filter { it.adyenRecurringDetailReference != null }

--- a/payment-service/src/test/java/com/hedvig/paymentservice/services/members/MemberServiceImplTest.kt
+++ b/payment-service/src/test/java/com/hedvig/paymentservice/services/members/MemberServiceImplTest.kt
@@ -37,7 +37,8 @@ class MemberServiceImplTest {
   fun `get one member with trustly connected when one member with trustly is provided`() {
     whenever(memberRepository.findAll()).thenReturn(listOf(
       buildMemberEntity(
-        trustlyAccountNumber = "123"
+        trustlyAccountNumber = "123",
+        directDebitStatus = DirectDebitStatus.CONNECTED
       )
     ))
 
@@ -50,11 +51,13 @@ class MemberServiceImplTest {
   fun `get two member with trustly connected when two member with trustly is provided`() {
     whenever(memberRepository.findAll()).thenReturn(listOf(
       buildMemberEntity(
-        trustlyAccountNumber = "123"
+        trustlyAccountNumber = "123",
+        directDebitStatus = DirectDebitStatus.CONNECTED
       ),
       buildMemberEntity(
         id = "1234",
-        trustlyAccountNumber = "123"
+        trustlyAccountNumber = "123",
+        directDebitStatus = DirectDebitStatus.CONNECTED
       )
     ))
 
@@ -81,7 +84,8 @@ class MemberServiceImplTest {
   fun `get one member with trustly connected when one member with trustly and one with adyen is provided`() {
     whenever(memberRepository.findAll()).thenReturn(listOf(
       buildMemberEntity(
-        trustlyAccountNumber = "123"
+        trustlyAccountNumber = "123",
+        directDebitStatus = DirectDebitStatus.CONNECTED
       ),
       buildMemberEntity(
         id = "1234",
@@ -98,7 +102,8 @@ class MemberServiceImplTest {
   fun `get one member with adyen connected when one member with trustly and one with adyen is provided`() {
     whenever(memberRepository.findAll()).thenReturn(listOf(
       buildMemberEntity(
-        trustlyAccountNumber = "123"
+        trustlyAccountNumber = "123",
+        directDebitStatus = DirectDebitStatus.CONNECTED
       ),
       buildMemberEntity(
         id = "1234",
@@ -113,13 +118,14 @@ class MemberServiceImplTest {
 
   @Test
   fun `if pay in provider is Trustly only return members who have direct debit connected`() {
-    val member1 = buildMemberEntity()
-    member1.directDebitStatus = DirectDebitStatus.DISCONNECTED
-    member1.trustlyAccountNumber = "321"
-
-    val member2 = buildMemberEntity()
-    member2.directDebitStatus = DirectDebitStatus.CONNECTED
-    member2.trustlyAccountNumber = "123"
+    val member1 = buildMemberEntity(
+      trustlyAccountNumber = "322",
+      directDebitStatus = DirectDebitStatus.DISCONNECTED
+    )
+    val member2 = buildMemberEntity(
+      trustlyAccountNumber = "222",
+      directDebitStatus = DirectDebitStatus.CONNECTED
+    )
 
     whenever(memberRepository.findAll()).thenReturn(listOf(member1, member2))
 
@@ -131,12 +137,14 @@ class MemberServiceImplTest {
   private fun buildMemberEntity(
     id: String = "321",
     trustlyAccountNumber: String? = null,
-    adyenRecurringDetailReference: String? = null
+    adyenRecurringDetailReference: String? = null,
+    directDebitStatus: DirectDebitStatus? = null
   ): Member {
     val member = Member()
     member.id = id
     member.trustlyAccountNumber = trustlyAccountNumber
     member.adyenRecurringDetailReference = adyenRecurringDetailReference
+    member.directDebitStatus = directDebitStatus
 
     return member
   }


### PR DESCRIPTION
Issue: We currently send termination emails and terminate members early who have once been connected with Trustly but are now disconnected. We should terminate on the 27th but have been terminating on the day we initiate charges (usually 2-3 days before the 27th).

We will now terminate these members on the 27th when we charge all members that have fallen outside Trustly or Adyen flows.