### PR TITLE
remove checking the memberRepository

### DIFF
--- a/payment-service/src/main/java/com/hedvig/paymentservice/services/segmentPublisher/TrustlyCustomerIoEventListener.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/services/segmentPublisher/TrustlyCustomerIoEventListener.kt
@@ -15,31 +15,20 @@ import org.springframework.stereotype.Component
 @Component
 @Profile("customer.io")
 @ProcessingGroup("TrustlySegmentProcessorGroup")
-@Order(2)
 class TrustlyCustomerIoEventListener(
-    val memberRepository: MemberRepository,
     val notificationService: NotificationService
 ) {
     @EventHandler
     fun on(evt: DirectDebitConnectedEvent) {
-        updateTraitsBasedOnDirectDebitStatus(DirectDebitStatus.CONNECTED, evt.memberId, evt.trustlyAccountId)
+        updateTraitsBasedOnDirectDebitStatus(DirectDebitStatus.CONNECTED, evt.memberId)
     }
 
     @EventHandler
     fun on(evt: DirectDebitDisconnectedEvent) {
-        updateTraitsBasedOnDirectDebitStatus(DirectDebitStatus.DISCONNECTED, evt.memberId, evt.trustlyAccountId)
+        updateTraitsBasedOnDirectDebitStatus(DirectDebitStatus.DISCONNECTED, evt.memberId)
     }
 
-    private fun updateTraitsBasedOnDirectDebitStatus(status: DirectDebitStatus, memberId: String, trustlyAccountId: String) {
-        val optionalMember = memberRepository.findById(memberId)
-        if (!optionalMember.isPresent) {
-            log.error(
-                "Cannot update direct debit status in notification service " +
-                    "Member $memberId cannot be found. TrustlyAccountId: $trustlyAccountId Status: ${status.name}"
-            )
-            return
-        }
-
+    private fun updateTraitsBasedOnDirectDebitStatus(status: DirectDebitStatus, memberId: String) {
         val traits = when (status) {
             DirectDebitStatus.PENDING,
             DirectDebitStatus.DISCONNECTED -> mapOf(IS_DIRECT_DEBIT_ACTIVATED to false)

--- a/payment-service/src/test/java/com/hedvig/paymentservice/services/segmentPublisher/TrustlyCustomerIoEventListenerTest.kt
+++ b/payment-service/src/test/java/com/hedvig/paymentservice/services/segmentPublisher/TrustlyCustomerIoEventListenerTest.kt
@@ -25,9 +25,6 @@ class TrustlyCustomerIoEventListenerTest {
     @Mock
     internal lateinit var notificationService: NotificationService
 
-    @Mock
-    lateinit var memberRepository: MemberRepository
-
     lateinit var sut: TrustlyCustomerIoEventListener
 
     lateinit var dataCaptor: KArgumentCaptor<Map<String, Any>>
@@ -35,8 +32,7 @@ class TrustlyCustomerIoEventListenerTest {
     @Before
     fun setup() {
         dataCaptor = argumentCaptor()
-        sut = TrustlyCustomerIoEventListener(memberRepository, notificationService)
-        `when`(memberRepository.findById(any())).thenReturn(Optional.of(Member()))
+        sut = TrustlyCustomerIoEventListener(notificationService)
     }
 
     @Test


### PR DESCRIPTION
The customerio event listener checks the db if there is a member, but the member event listener is too slow to commit the change to the db. 

How is fix this? 
- Removing the check in the database :D 

Logs from datadog
https://app.datadoghq.eu/logs?cols=pod_name&from_ts=1609838957416&index=&live=true&messageDisplay=inline&query=service%3Apayment-service%20Cannot%20update%20direct%20debit%20status%20in%20notification%20service&stream_sort=desc&to_ts=1610443757416