### PR TITLE
Return tokenization result instead of payoutStatus

### DIFF
--- a/payment-service/src/main/java/com/hedvig/paymentservice/graphQl/Mutation.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/graphQl/Mutation.kt
@@ -3,20 +3,18 @@ package com.hedvig.paymentservice.graphQl
 import com.coxautodev.graphql.tools.GraphQLMutationResolver
 import com.hedvig.graphql.commons.extensions.getEndUserIp
 import com.hedvig.graphql.commons.extensions.getTokenOrNull
-import com.hedvig.paymentservice.graphQl.types.ActivePayoutMethodsResponse
 import com.hedvig.paymentservice.graphQl.types.AdditionalPaymentsDetailsRequest
 import com.hedvig.paymentservice.graphQl.types.AdditionalPaymentsDetailsResponse
 import com.hedvig.paymentservice.graphQl.types.CancelDirectDebitStatus
 import com.hedvig.paymentservice.graphQl.types.DirectDebitResponse
-import com.hedvig.paymentservice.graphQl.types.PayoutMethodStatus
 import com.hedvig.paymentservice.graphQl.types.RegisterDirectDebitClientContext
 import com.hedvig.paymentservice.graphQl.types.SubmitAdyenRedirectionRequest
 import com.hedvig.paymentservice.graphQl.types.SubmitAdyenRedirectionResponse
 import com.hedvig.paymentservice.graphQl.types.TokenizationRequest
 import com.hedvig.paymentservice.graphQl.types.TokenizationResponse
+import com.hedvig.paymentservice.graphQl.types.TokenizationResultType
 import com.hedvig.paymentservice.serviceIntergration.memberService.MemberService
 import com.hedvig.paymentservice.services.adyen.AdyenService
-import com.hedvig.paymentservice.services.adyen.dtos.PaymentResponseResultCode
 import com.hedvig.paymentservice.services.trustly.TrustlyService
 import com.hedvig.paymentservice.services.trustly.dto.DirectDebitOrderInfo.Companion.fromMember
 import graphql.schema.DataFetchingEnvironment
@@ -73,7 +71,7 @@ class Mutation(
 
         return TokenizationResponse.TokenizationResponseFinished(
             resultCode = adyenResponse.paymentsResponse.resultCode.value,
-            activePayoutMethods = null
+            tokenizationResult = TokenizationResultType.from(adyenResponse.getResultCode())
         )
     }
 
@@ -99,9 +97,7 @@ class Mutation(
 
         return TokenizationResponse.TokenizationResponseFinished(
             resultCode = adyenResponse.paymentsResponse.resultCode.value,
-            activePayoutMethods = ActivePayoutMethodsResponse(
-                status = PayoutMethodStatus.from(adyenResponse.getResultCode())
-            )
+            tokenizationResult = TokenizationResultType.from(adyenResponse.getResultCode())
         )
     }
 
@@ -124,7 +120,8 @@ class Mutation(
         }
 
         return AdditionalPaymentsDetailsResponse.AdditionalPaymentsDetailsResponseFinished(
-            resultCode = adyenResponse.paymentsResponse.resultCode.value
+            resultCode = adyenResponse.paymentsResponse.resultCode.value,
+            tokenizationResult = TokenizationResultType.from(adyenResponse.getResultCode())
         )
     }
 

--- a/payment-service/src/main/java/com/hedvig/paymentservice/graphQl/types/AdditionalPaymentsDetailsResponse.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/graphQl/types/AdditionalPaymentsDetailsResponse.kt
@@ -3,11 +3,12 @@ package com.hedvig.paymentservice.graphQl.types
 import com.adyen.model.checkout.CheckoutPaymentsAction
 
 sealed class AdditionalPaymentsDetailsResponse {
-  data class AdditionalPaymentsDetailsResponseFinished(
-    val resultCode: String
-  ) : AdditionalPaymentsDetailsResponse()
+    data class AdditionalPaymentsDetailsResponseFinished(
+        val resultCode: String,
+        val tokenizationResult: TokenizationResultType
+    ) : AdditionalPaymentsDetailsResponse()
 
-  data class AdditionalPaymentsDetailsResponseAction(
-    val action: CheckoutPaymentsAction
-  ) : AdditionalPaymentsDetailsResponse()
+    data class AdditionalPaymentsDetailsResponseAction(
+        val action: CheckoutPaymentsAction
+    ) : AdditionalPaymentsDetailsResponse()
 }

--- a/payment-service/src/main/java/com/hedvig/paymentservice/graphQl/types/TokenizationResponse.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/graphQl/types/TokenizationResponse.kt
@@ -6,7 +6,7 @@ sealed class TokenizationResponse() {
 
     data class TokenizationResponseFinished(
         val resultCode: String,
-        val activePayoutMethods: ActivePayoutMethodsResponse?
+        val tokenizationResult: TokenizationResultType
     ) : TokenizationResponse()
 
     data class TokenizationResponseAction(

--- a/payment-service/src/main/java/com/hedvig/paymentservice/graphQl/types/TokenizationResultType.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/graphQl/types/TokenizationResultType.kt
@@ -1,0 +1,17 @@
+package com.hedvig.paymentservice.graphQl.types
+
+import com.hedvig.paymentservice.services.adyen.dtos.PaymentResponseResultCode
+
+enum class TokenizationResultType {
+    AUTHORIZED,
+    PENDING,
+    FAILED;
+
+    companion object {
+        fun from(resultCode: PaymentResponseResultCode) = when (resultCode) {
+            PaymentResponseResultCode.AUTHORISED -> AUTHORIZED
+            PaymentResponseResultCode.PENDING -> PENDING
+            PaymentResponseResultCode.FAILED -> FAILED
+        }
+    }
+}

--- a/payment-service/src/main/java/com/hedvig/paymentservice/graphQl/types/TokenizationResultType.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/graphQl/types/TokenizationResultType.kt
@@ -3,13 +3,13 @@ package com.hedvig.paymentservice.graphQl.types
 import com.hedvig.paymentservice.services.adyen.dtos.PaymentResponseResultCode
 
 enum class TokenizationResultType {
-    AUTHORIZED,
+    AUTHORISED,
     PENDING,
     FAILED;
 
     companion object {
         fun from(resultCode: PaymentResponseResultCode) = when (resultCode) {
-            PaymentResponseResultCode.AUTHORISED -> AUTHORIZED
+            PaymentResponseResultCode.AUTHORISED -> AUTHORISED
             PaymentResponseResultCode.PENDING -> PENDING
             PaymentResponseResultCode.FAILED -> FAILED
         }

--- a/payment-service/src/main/resources/schema.graphqls
+++ b/payment-service/src/main/resources/schema.graphqls
@@ -55,6 +55,12 @@ enum TokenizationChannel{
     WEB
 }
 
+enum TokenizationResultType {
+    AUTHORISED
+    PENDING
+    FAILED
+}
+
 input BrowserInfo{
     userAgent: String!
     acceptHeader: String!
@@ -80,7 +86,7 @@ union TokenizationResponse = TokenizationResponseFinished | TokenizationResponse
 
 type TokenizationResponseFinished {
     resultCode: String!
-    activePayoutMethods: ActivePayoutMethodsResponse
+    tokenizationResult: TokenizationResultType!
 }
 
 type TokenizationResponseAction {
@@ -91,6 +97,7 @@ union AdditionalPaymentsDetailsResponse = AdditionalPaymentsDetailsResponseFinis
 
 type AdditionalPaymentsDetailsResponseFinished {
     resultCode: String!
+    tokenizationResult: TokenizationResultType!
 }
 
 type AdditionalPaymentsDetailsResponseAction {
@@ -132,6 +139,7 @@ enum PayinMethodStatus{
     PENDING
     NEEDS_SETUP
 }
+
 enum DirectDebitStatus {
     ACTIVE
     PENDING

--- a/trustly-client/src/main/java/com/hedvig/paymentService/trustly/SignedAPI.java
+++ b/trustly-client/src/main/java/com/hedvig/paymentService/trustly/SignedAPI.java
@@ -32,13 +32,11 @@ import com.hedvig.paymentService.trustly.commons.exceptions.TrustlySignatureExce
 import com.hedvig.paymentService.trustly.data.request.Request;
 import com.hedvig.paymentService.trustly.data.response.Response;
 import com.hedvig.paymentService.trustly.security.SignatureHandler;
-
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URISyntaxException;
 import java.security.KeyException;
 import java.security.SecureRandom;
-
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;


### PR DESCRIPTION
# Jira Issue: []

## What?
- Return `TokenizationResultType` instead of ActivePayoutsStatus when performing different tokenizations

## Why?
- Because the previous solution was very very payout specific without any clear gain, rather give a generic response that can be utilized differently for different cases where payout is one of them, without cluttering the code.

## Optional checklist
- [ ] Codecouted
- [ ] Unit tests written
- [ ] Tested locally

