### PR TITLE
Enable disabling trustly payouts via adyen

### DIFF
--- a/payment-service/src/main/java/com/hedvig/paymentservice/services/adyen/AdyenServiceImpl.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/services/adyen/AdyenServiceImpl.kt
@@ -92,6 +92,8 @@ class AdyenServiceImpl(
     val memberAdyenAccountRepository: MemberAdyenAccountRepository,
     @param:Value("\${hedvig.adyen.allow3DS2}")
     val allow3DS2: Boolean,
+    @param:Value("\${hedvig.adyen.allowTrustlyPayouts}")
+    val allowTrustlyPayouts: Boolean,
     @param:Value("\${hedvig.adyen.public.key}")
     val adyenPublicKey: String,
     @param:Value("\${hedvig.adyen.charge.autorescue.scenario}")
@@ -106,6 +108,9 @@ class AdyenServiceImpl(
     override fun getAvailablePayoutMethods(memberId: String): AvailablePaymentMethodsResponse {
         val response: PaymentMethodsResponse = getAvailablePaymentMethods(memberId)
         response.paymentMethods = includeOnlyTrustlyFromAvailablePayoutMethods(response.paymentMethods)
+        if (!allowTrustlyPayouts) {
+            excludeTrustlyFromAvailablePayoutMethods(response.paymentMethods)
+        }
         return AvailablePaymentMethodsResponse(paymentMethodsResponse = response)
     }
 
@@ -746,6 +751,9 @@ class AdyenServiceImpl(
 
     private fun includeOnlyTrustlyFromAvailablePayoutMethods(listOfAvailablePayoutMethods: List<PaymentMethod>): List<PaymentMethod> =
         listOfAvailablePayoutMethods.filter { it.type.toLowerCase() == TRUSTLY }
+
+    private fun excludeTrustlyFromAvailablePayoutMethods(listOfAvailablePayoutMethods: List<PaymentMethod>): List<PaymentMethod> =
+        listOfAvailablePayoutMethods.filter { it.type.toLowerCase() != TRUSTLY }
 
     private fun excludeTrustlyFromAvailablePaymentMethods(listOfAvailablePaymentMethods: List<PaymentMethod>): List<PaymentMethod> =
         listOfAvailablePaymentMethods.filter { it.type.toLowerCase() != TRUSTLY }

--- a/payment-service/src/main/java/com/hedvig/paymentservice/services/adyen/AdyenServiceImpl.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/services/adyen/AdyenServiceImpl.kt
@@ -109,7 +109,7 @@ class AdyenServiceImpl(
         val response: PaymentMethodsResponse = getAvailablePaymentMethods(memberId)
         response.paymentMethods = includeOnlyTrustlyFromAvailablePayoutMethods(response.paymentMethods)
         if (!allowTrustlyPayouts) {
-            excludeTrustlyFromAvailablePayoutMethods(response.paymentMethods)
+            response.paymentMethods = excludeTrustlyFromAvailablePayoutMethods(response.paymentMethods)
         }
         return AvailablePaymentMethodsResponse(paymentMethodsResponse = response)
     }

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -17,7 +17,6 @@ spring:
 spring.jpa.generate-ddl: true
 spring.jpa.properties.hibernate.dialect: com.hedvig.paymentservice.PostgresDialect
 
-
 graphql:
     servlet:
         mapping: /graphql
@@ -37,6 +36,7 @@ hedvig:
         public:
             key: test
         allow3DS2: true
+        allowTrustlyPayouts: true
         returnUrl: test
         merchantAccount: test
         enviroment: TEST

--- a/payment-service/src/test/java/com/hedvig/paymentservice/services/adyen/AdyenServiceTest.kt
+++ b/payment-service/src/test/java/com/hedvig/paymentservice/services/adyen/AdyenServiceTest.kt
@@ -92,6 +92,7 @@ class AdyenServiceTest {
             adyenMerchantPicker = adyenMerchantPicker,
             memberAdyenAccountRepository = memberAdyenAccountRepository,
             allow3DS2 = true,
+            allowTrustlyPayouts = true,
             adyenPublicKey = "",
             autoRescueScenario = null
         )

--- a/payment-service/src/test/resources/application-test.yml
+++ b/payment-service/src/test/resources/application-test.yml
@@ -19,6 +19,7 @@ spring.jpa.hibernate.ddl-auto: create
 hedvig:
   adyen:
     allow3DS2: true
+    allowTrustlyPayouts: true
     returnUrl: test
     merchantAccount: test
     enviroment: TEST


### PR DESCRIPTION
# Jira Issue: [HVG-868]

## What?
- Add ability to disable Trustly payouts via Adyen

## Why?
- So we can safely deploy the app with payouts enabled without it showing up

## Optional checklist
- [ ] Codecouted
- [ ] Unit tests written
- [ ] Tested locally



[HVG-868]: https://hedvig.atlassian.net/browse/HVG-868