### PR TITLE
add missing handler field from PayoutCreatedEvent

### DIFF
--- a/payment-service/src/main/java/com/hedvig/paymentservice/domain/payments/Member.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/domain/payments/Member.kt
@@ -168,6 +168,7 @@ class Member() {
                         category = command.category,
                         referenceId = command.referenceId,
                         note = command.note,
+                        handler = command.handler,
                         email = command.email,
                         carrier = command.carrier,
                         payoutDetails = PayoutDetails.Swish(
@@ -195,6 +196,7 @@ class Member() {
                             category = command.category,
                             referenceId = command.referenceId,
                             note = command.note,
+                            handler = command.handler,
                             email = command.email,
                             carrier = command.carrier,
                             payoutDetails = PayoutDetails.Trustly(trustlyAccount.accountId)
@@ -223,6 +225,7 @@ class Member() {
                         category = command.category,
                         referenceId = command.referenceId,
                         note = command.note,
+                        handler = command.handler,
                         email = command.email,
                         carrier = command.carrier,
                         payoutDetails = PayoutDetails.Adyen(account.shopperReference)

--- a/payment-service/src/main/java/com/hedvig/paymentservice/domain/payments/events/PayoutCreatedEvent.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/domain/payments/events/PayoutCreatedEvent.kt
@@ -22,6 +22,7 @@ data class PayoutCreatedEvent(
     val category: TransactionCategory,
     val referenceId: String?,
     val note: String?,
+    val handler: String?,
     val email: String?,
     val carrier: Carrier?,
     val payoutDetails: PayoutDetails

--- a/payment-service/src/test/java/com/hedvig/paymentservice/domain/payments/MemberTest.kt
+++ b/payment-service/src/test/java/com/hedvig/paymentservice/domain/payments/MemberTest.kt
@@ -546,6 +546,7 @@ class MemberTest {
         category = TransactionCategory.CLAIM,
         referenceId = null,
         note = null,
+        handler = null,
         carrier = Carrier.HDI,
         payoutDetails = PayoutDetails.Trustly(trustlyAccountId!!)
     )


### PR DESCRIPTION
# Jira Issue: []

## What?
- Add missing field `handler` in the PayoutCreatedEvent

## Why?
- Because it breaks when we load the existing aggregates 

## Optional checklist
- [ ] Codecouted
- [ ] Unit tests written
- [ ] Tested locally

