### PR TITLE
correctly format swish instruction date

### DIFF
--- a/payment-service/src/main/java/com/hedvig/paymentservice/services/swish/SwishService.kt
+++ b/payment-service/src/main/java/com/hedvig/paymentservice/services/swish/SwishService.kt
@@ -10,9 +10,12 @@ import com.hedvig.paymentservice.services.swish.util.SwishSignatureCreator
 import com.hedvig.paymentservice.services.swish.util.SwishUUIDConverter
 import feign.FeignException
 import org.springframework.stereotype.Service
+import java.text.DateFormat
 import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.UUID
 import javax.money.MonetaryAmount
+import javax.swing.text.DateFormatter
 
 @Service
 class SwishService(
@@ -20,6 +23,9 @@ class SwishService(
     private val client: SwishClient,
     private val properties : SwishConfigurationProperties
 ) {
+
+    private val swishDateFormat: DateTimeFormatter = DateTimeFormatter.ofPattern(("yyyy-MM-dd'T'HH:mm:ss'Z'"))
+
     fun startPayout(
         transactionId: UUID,
         memberId: String,
@@ -38,7 +44,7 @@ class SwishService(
             amount = String.format("%.2f", amount.number.doubleValueExact()),
             currency = amount.currency.currencyCode,
             message = message,
-            instructionDate = "2021-03-11T13:45:36Z",
+            instructionDate = instructionDate.format(swishDateFormat),
             signingCertificateSerialNumber = properties.signingCertificateSerialNumber
         )
         val json = objectMapper.writeValueAsString(payload)

--- a/payment-service/src/test/java/com/hedvig/paymentservice/services/swish/SwishServiceTest.kt
+++ b/payment-service/src/test/java/com/hedvig/paymentservice/services/swish/SwishServiceTest.kt
@@ -45,7 +45,7 @@ class SwishServiceTest {
             payeeSSN = payeeSSN,
             amount = amount,
             message = message,
-            instructionDate = LocalDateTime.now(),
+            instructionDate = LocalDateTime.of(2021, 3, 29, 10, 14),
         )
 
         val payoutRequest = slot.captured
@@ -56,6 +56,7 @@ class SwishServiceTest {
         assertThat(payoutRequest.payload.payeeAlias).isEqualTo(payeeAlias)
         assertThat(payoutRequest.payload.payeeSSN).isEqualTo(payeeSSN)
         assertThat(payoutRequest.payload.message).isEqualTo(message)
+        assertThat(payoutRequest.payload.instructionDate).isEqualTo("2021-03-29T10:14:00Z")
     }
 
     companion object {


### PR DESCRIPTION
## What?
- Correctly format swish instruction date

## Why?
- Because it was hardcoded while testing

## Optional checklist
- [ ] Codecouted
- [ ] Unit tests written
- [x] Tested locally

